### PR TITLE
hotfix: add slash to static and media urls

### DIFF
--- a/scentifique/settings.py
+++ b/scentifique/settings.py
@@ -220,8 +220,8 @@ if "USE_AWS" in os.environ:
     DEFAULT_FILE_STORAGE = "custom_storages.MediaStorage"
     MEDIAFILES_LOCATION = "media"
     # Override static and media files in production
-    STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{STATICFILES_LOCATION}"
-    MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{MEDIAFILES_LOCATION}"
+    STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{STATICFILES_LOCATION}/"
+    MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{MEDIAFILES_LOCATION}/"
     # Cache for static and media files
     AWS_S3_OBJECT_PARAMETERS = {
         "Expires": "Thu, 31 Dec 2099 20:00:00 GMT",


### PR DESCRIPTION
Added trailing slashes to static and media URLs in production as this may be stopping `manage.py dumpdata` from working.